### PR TITLE
Fix lifeCycles method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -22,7 +22,7 @@ export const hookus = hookFunction => {
   };
 };
 const runLifeCycles = (context, name) => {
-  const promises = hookDataStack[runMap.stackIndex]
+  const promises = (hookDataStack[runMap.stackIndex] || [])
     .map(data => {
       if (data[0] && data[0][name]) {
         const result = data[0][name]();

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -25,6 +25,21 @@ test("nested pocus runs don't fail", () => {
   pocus(test1);
 });
 
+test("sub pocus run don't fail", () => {
+  const test1State = 1;
+  const test2State = 2;
+  function test2() {
+    const [state] = useState(test2State);
+    expect(state).toBe(test2State);
+  }
+  function test1() {
+    const [state] = useState(test1State);
+    expect(state).toBe(test1State);
+    pocus(test2);
+  }
+  pocus(test1);
+});
+
 test("hooks defined with hokus can be used in pocus and are passed arguments", () => {
   const arg = "test";
   const useTest = hookus((data, argIn) => {


### PR DESCRIPTION
Accept empty array when map ```hookDataStack``` return ```undefined```. This happen when you call pocus within another hook function. i.e

```js
function test2() {
  const [state] = useState(2);
}

function test1() {
  const [state] = useState(1);
  pocus(test2);
}

pocus(test1);
```